### PR TITLE
Prevent duplicate storefront items

### DIFF
--- a/app/models/storefront_item.js
+++ b/app/models/storefront_item.js
@@ -4,7 +4,8 @@ const storefrontItemSchema = new mongoose.Schema({
   warehouseItem: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'WarehouseItem',
-    requried: true
+    required: true,
+    unique: true
   },
   owner: {
     type: mongoose.Schema.Types.ObjectId,


### PR DESCRIPTION
- establish warehouseItem field as index in storefrontitems collection
- add 'unique' parameter to storefront_item model for warehouseItem

- replace StorefrontItem.create(. . .) with .findOneAndUpdate()
to leverage upsert behavior upon creation.
- create behavior will now create non-existing doc or update existing
doc. Will not create duplicate doc.