### PR TITLE
Duplicate storefront item

### DIFF
--- a/app/models/storefront_item.js
+++ b/app/models/storefront_item.js
@@ -4,7 +4,8 @@ const storefrontItemSchema = new mongoose.Schema({
   warehouseItem: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'WarehouseItem',
-    requried: true
+    required: true,
+    unique: true
   },
   owner: {
     type: mongoose.Schema.Types.ObjectId,

--- a/app/routes/storefront_item_routes.js
+++ b/app/routes/storefront_item_routes.js
@@ -70,7 +70,6 @@ router.post('/storefront-items', requireToken, (req, res, next) => {
     // the error handler needs the error message and the `res` object so that it
     // can send an error message back to the client
     .catch(next)
-  // }
 })
 
 // UPDATE


### PR DESCRIPTION
pull request contains code that prevents duplicate storefront items from being created. The behavior is such that it will either create a new doc where none exists or update the existing document with the provided form data.